### PR TITLE
Add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/ZeroErrors/go-bedrockping
+
+go 1.13


### PR DESCRIPTION
This adds go.mod (as generated by ```go mod init```) to enable Go's modules functionality.

You can publish a versioned release (for use as a dependency) using git tags:
```
$ git tag v1.0.0
$ git push origin v1.0.0
```

More information: https://blog.golang.org/publishing-go-modules